### PR TITLE
Return the output file name

### DIFF
--- a/scidownl/core/task.py
+++ b/scidownl/core/task.py
@@ -86,3 +86,4 @@ class ScihubTask(BaseTask):
         downloader.download(out)
         scihub_url = self.context.get('referer', None)
         self.service.increment_success_times(scihub_url)
+        return out


### PR DESCRIPTION
Hello, thanks for the amazing tool. I suggest to return the downloaded file name, so we can manupulate the file if the user has not input a file name.