### PR TITLE
add timeout argument

### DIFF
--- a/scidownl/api/scihub.py
+++ b/scidownl/api/scihub.py
@@ -9,7 +9,8 @@ def scihub_download(
         paper_type: str = 'doi',
         scihub_url: str = None,
         out: str = None,
-        proxies: dict = None
+        proxies: dict = None,
+        timeout: int = None,
     ) -> None:
     """Download a paper from SciHub.
 
@@ -33,6 +34,7 @@ def scihub_download(
         source_type=paper_type,
         scihub_url=scihub_url,
         out=out,
-        proxies=proxies
+        proxies=proxies,
+        timeout=timeout
     ).run()
 

--- a/scidownl/core/crawler.py
+++ b/scidownl/core/crawler.py
@@ -34,9 +34,10 @@ class ScihubCrawler(BaseCrawler, BaseTaskStep):
                 'request': self.source[self.source.type]
             }
             proxies = self.task.context.get('proxies', {}) if self.task is not None else {}
+            timeout = self.task.context.get('timeout', None) if self.task is not None else None
             logger.info(f"<- Request: scihub_url={self.scihub_url}, source={self.source}, proxies={proxies}")
 
-            res = self.sess.post(self.scihub_url, data=request_params, proxies=proxies)
+            res = self.sess.post(self.scihub_url, data=request_params, proxies=proxies, timeout=timeout)
             logger.info(f"-> Response: status_code={res.status_code}, content_length={len(res.content.decode())}")
 
             if res.status_code not in ScihubCrawler.OK_STATUS_CODES:

--- a/scidownl/core/downloader.py
+++ b/scidownl/core/downloader.py
@@ -31,7 +31,8 @@ class UrlDownloader(BaseDownloader, BaseTaskStep):
         try:
             url = self.information.get_url()
             proxies = self.task.context.get('proxies', {}) if self.task is not None else {}
-            res = requests.get(url, stream=True, proxies=proxies)
+            timeout = self.task.context.get('timeout', None) if self.task is not None else None
+            res = requests.get(url, stream=True, proxies=proxies, timeout=timeout)
             total_length = res.headers.get('content-length')
 
             with open(out, "wb") as f:

--- a/scidownl/core/task.py
+++ b/scidownl/core/task.py
@@ -28,7 +28,8 @@ class ScihubTask(BaseTask):
                  scihub_url: str = None,
                  scihub_url_chooser_cls=default_chooser_cls,
                  out: str = None,
-                 proxies: dict = None):
+                 proxies: dict = None,
+                 timeout: int = None):
         super().__init__()
         self.source_keyword = source_keyword
         self.scihub_url_chooser_cls = scihub_url_chooser_cls
@@ -37,8 +38,10 @@ class ScihubTask(BaseTask):
         self.source_class = source_classes.get(source_type, DoiSource)
         self.out = out
         self.proxies = proxies or {}
+        self.timeout = timeout
         self.context['status'] = 'initialized'
         self.context['proxies'] = self.proxies
+        self.context['timeout'] = timeout
         self.service = ScihubUrlService()
         self.updater = CrawlingScihubDomainUpdater()
 


### PR DESCRIPTION
Sometimes the crawler freezes because there is no timeout defined for the http request.

We can prevent that by passing a timetout argument.